### PR TITLE
Remove americanisations

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
+Examples of behaviour that contributes to creating a positive environment
 include:
 
 * Using welcoming and inclusive language
@@ -20,9 +20,9 @@ include:
 * Focusing on what is best for the community
 * Showing empathy towards other community members
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behaviour by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+* The use of sexualised language or imagery and unwelcome sexual attention or
 advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
@@ -34,13 +34,13 @@ advances
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+behaviour and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
+permanently any contributor for other behaviours that they deem inappropriate,
 threatening, offensive, or harmful.
 
 ## Scope
@@ -54,7 +54,7 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported by contacting the project team at [help@openflighthpc.org](help@openflighthpc.org). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ document to understand what you can do:
 
  * [Code of Conduct](#code-of-conduct)
  * [Help Others](#help-others)
- * [Analyze Issues](#analyze-issues)
+ * [Analyse Issues](#analyse-issues)
  * [Report an Issue](#report-an-issue)
  * [Contribute Changes](#contribute-changes)
 
@@ -23,15 +23,15 @@ follow it in all your interactions with the project.
 This project and everyone participating in it is governed by the
 [OpenFlight Code of Conduct](CODE_OF_CONDUCT.md). By participating,
 you are expected to uphold this code. Please report unacceptable
-behavior to [help@openflighthpc.org](mailto:help@openflighthpc.org).
+behaviour to [help@openflighthpc.org](mailto:help@openflighthpc.org).
 
 ## Help Others
 
 You can help %PROJECT% by helping others who use it and need support.
 
-## Analyze Issues
+## Analyse Issues
 
-Analyzing issue reports can be a lot of effort. Any help is welcome!
+Analysing issue reports can be a lot of effort. Any help is welcome!
 Go to [the GitHub issue tracker](https://github.com/openflighthpc/%GITHUB-PROJECT%/issues?state=open)
 and find an open issue which needs additional work or a bugfix
 (e.g. issues labeled with "help wanted" or "bug").
@@ -42,12 +42,12 @@ even find and [contribute](#contribute-changes) a bugfix?
 
 ## Report an Issue
 
-If you find a bug - behavior of %PROJECT% code or documentation
+If you find a bug - behaviour of %PROJECT% code or documentation
 contradicting your expectation - you are welcome to report it. We can
 only handle well-reported, actual bugs, so please follow the
 guidelines below.
 
-Once you have familiarized with the guidelines, you can go to the
+Once you have familiarised with the guidelines, you can go to the
 [GitHub issue tracker for %PROJECT%](https://github.com/openflighthpc/%GITHUB-PROJECT%/issues/new)
 to report the issue.
 
@@ -82,7 +82,7 @@ before it can be exploited.  Please send the related information to
 We want to improve the quality of %PROJECT% and good bug reports are
 welcome! However, our capacity is limited, thus we reserve the right
 to close or to not process bug reports with insufficient detail in
-favor of those which are very cleanly documented and easy to
+favour of those which are very cleanly documented and easy to
 reproduce. Even though we would like to solve each well-documented
 issue, there is always the chance that it will not happen - remember:
 %PROJECT% is Open Source and comes without warranty.

--- a/templates/CC-BY-SA/CODE_OF_CONDUCT.md
+++ b/templates/CC-BY-SA/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
+Examples of behaviour that contributes to creating a positive environment
 include:
 
 * Using welcoming and inclusive language
@@ -20,9 +20,9 @@ include:
 * Focusing on what is best for the community
 * Showing empathy towards other community members
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behaviour by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+* The use of sexualised language or imagery and unwelcome sexual attention or
 advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
@@ -34,13 +34,13 @@ advances
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+behaviour and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
+permanently any contributor for other behaviours that they deem inappropriate,
 threatening, offensive, or harmful.
 
 ## Scope
@@ -54,7 +54,7 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported by contacting the project team at [help@openflighthpc.org](help@openflighthpc.org). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is

--- a/templates/CC-BY-SA/CONTRIBUTING.md
+++ b/templates/CC-BY-SA/CONTRIBUTING.md
@@ -7,7 +7,7 @@ document to understand what you can do:
 
  * [Code of Conduct](#code-of-conduct)
  * [Help Others](#help-others)
- * [Analyze Issues](#analyze-issues)
+ * [Analyse Issues](#analyse-issues)
  * [Report an Issue](#report-an-issue)
  * [Contribute Changes](#contribute-changes)
 
@@ -23,15 +23,15 @@ follow it in all your interactions with the project.
 This project and everyone participating in it is governed by the
 [OpenFlight Code of Conduct](CODE_OF_CONDUCT.md). By participating,
 you are expected to uphold this code. Please report unacceptable
-behavior to [help@openflighthpc.org](mailto:help@openflighthpc.org).
+behaviour to [help@openflighthpc.org](mailto:help@openflighthpc.org).
 
 ## Help Others
 
 You can help %PROJECT% by helping others who use it and need support.
 
-## Analyze Issues
+## Analyse Issues
 
-Analyzing issue reports can be a lot of effort. Any help is welcome!
+Analysing issue reports can be a lot of effort. Any help is welcome!
 Go to [the GitHub issue tracker](https://github.com/openflighthpc/%GITHUB-PROJECT%/issues?state=open)
 and find an open issue which needs additional work or a bugfix
 (e.g. issues labeled with "help wanted" or "bug").
@@ -42,12 +42,12 @@ even find and [contribute](#contribute-changes) a bugfix?
 
 ## Report an Issue
 
-If you find a bug - behavior of %PROJECT% code or documentation
+If you find a bug - behaviour of %PROJECT% code or documentation
 contradicting your expectation - you are welcome to report it. We can
 only handle well-reported, actual bugs, so please follow the
 guidelines below.
 
-Once you have familiarized with the guidelines, you can go to the
+Once you have familiarised with the guidelines, you can go to the
 [GitHub issue tracker for %PROJECT%](https://github.com/openflighthpc/%GITHUB-PROJECT%/issues/new)
 to report the issue.
 
@@ -82,7 +82,7 @@ before it can be exploited.  Please send the related information to
 We want to improve the quality of %PROJECT% and good bug reports are
 welcome! However, our capacity is limited, thus we reserve the right
 to close or to not process bug reports with insufficient detail in
-favor of those which are very cleanly documented and easy to
+favour of those which are very cleanly documented and easy to
 reproduce. Even though we would like to solve each well-documented
 issue, there is always the chance that it will not happen - remember:
 %PROJECT% is Open Source and comes without warranty.

--- a/templates/EPL-2.0/CODE_OF_CONDUCT.md
+++ b/templates/EPL-2.0/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
+Examples of behaviour that contributes to creating a positive environment
 include:
 
 * Using welcoming and inclusive language
@@ -20,9 +20,9 @@ include:
 * Focusing on what is best for the community
 * Showing empathy towards other community members
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behaviour by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
+* The use of sexualised language or imagery and unwelcome sexual attention or
 advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
@@ -34,13 +34,13 @@ advances
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+behaviour and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
+permanently any contributor for other behaviours that they deem inappropriate,
 threatening, offensive, or harmful.
 
 ## Scope
@@ -54,7 +54,7 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
 reported by contacting the project team at [help@openflighthpc.org](help@openflighthpc.org). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is

--- a/templates/EPL-2.0/CONTRIBUTING.md
+++ b/templates/EPL-2.0/CONTRIBUTING.md
@@ -7,7 +7,7 @@ document to understand what you can do:
 
  * [Code of Conduct](#code-of-conduct)
  * [Help Others](#help-others)
- * [Analyze Issues](#analyze-issues)
+ * [Analyse Issues](#analyse-issues)
  * [Report an Issue](#report-an-issue)
  * [Contribute Changes](#contribute-changes)
 
@@ -23,15 +23,15 @@ follow it in all your interactions with the project.
 This project and everyone participating in it is governed by the
 [OpenFlight Code of Conduct](CODE_OF_CONDUCT.md). By participating,
 you are expected to uphold this code. Please report unacceptable
-behavior to [help@openflighthpc.org](mailto:help@openflighthpc.org).
+behaviour to [help@openflighthpc.org](mailto:help@openflighthpc.org).
 
 ## Help Others
 
 You can help %PROJECT% by helping others who use it and need support.
 
-## Analyze Issues
+## Analyse Issues
 
-Analyzing issue reports can be a lot of effort. Any help is welcome!
+Analysing issue reports can be a lot of effort. Any help is welcome!
 Go to [the GitHub issue tracker](https://github.com/openflighthpc/%GITHUB-PROJECT%/issues?state=open)
 and find an open issue which needs additional work or a bugfix
 (e.g. issues labeled with "help wanted" or "bug").
@@ -42,12 +42,12 @@ even find and [contribute](#contribute-changes) a bugfix?
 
 ## Report an Issue
 
-If you find a bug - behavior of %PROJECT% code or documentation
+If you find a bug - behaviour of %PROJECT% code or documentation
 contradicting your expectation - you are welcome to report it. We can
 only handle well-reported, actual bugs, so please follow the
 guidelines below.
 
-Once you have familiarized with the guidelines, you can go to the
+Once you have familiarised with the guidelines, you can go to the
 [GitHub issue tracker for %PROJECT%](https://github.com/openflighthpc/%GITHUB-PROJECT%/issues/new)
 to report the issue.
 
@@ -82,7 +82,7 @@ before it can be exploited.  Please send the related information to
 We want to improve the quality of %PROJECT% and good bug reports are
 welcome! However, our capacity is limited, thus we reserve the right
 to close or to not process bug reports with insufficient detail in
-favor of those which are very cleanly documented and easy to
+favour of those which are very cleanly documented and easy to
 reproduce. Even though we would like to solve each well-documented
 issue, there is always the chance that it will not happen - remember:
 %PROJECT% is Open Source and comes without warranty.


### PR DESCRIPTION
Replace instances of behavior with behaviour and remove any other
americanisations from the documents. This is to keep the spelling and
use of language consistent for existing tools which have been written
with UK English spelling #brexit.